### PR TITLE
Fix some issues running both posh-git and posh-svn together

### DIFF
--- a/SvnPrompt.ps1
+++ b/SvnPrompt.ps1
@@ -48,11 +48,13 @@ function Write-SvnStatus($status) {
 }
 
 # Should match https://github.com/dahlbyk/posh-git/blob/master/GitPrompt.ps1
-if (!$Global:VcsPromptStatuses) { $Global:VcsPromptStatuses = @() }
-function Global:WriteVcsStatus { $Global:VcsPromptStatuses | foreach { & $_ } }
+if((Get-Variable -Scope Global -Name VcsPromptStatuses -ErrorAction SilentlyContinue) -eq $null) {
+    $Global:VcsPromptStatuses = @()
+}
+function Global:Write-VcsStatus { $Global:VcsPromptStatuses | foreach { & $_ } }
 
-# Scriptblock that will execute for write-vcsstatus
+# Add scriptblock that will execute for Write-VcsStatus
 $Global:VcsPromptStatuses += {
-	$Global:SvnStatus = Get-SvnStatus
-	Write-SvnStatus $SvnStatus
+    $Global:SvnStatus = Get-SvnStatus
+    Write-SvnStatus $SvnStatus
 }

--- a/SvnTabExpansion.ps1
+++ b/SvnTabExpansion.ps1
@@ -76,3 +76,20 @@ $tsvnCommands = @{
 "rebuildiconcache" = @{ cmd = "rebuildiconcache"; useCurrentDirectory = $false };
 "properties" = @{ cmd = "properties"; useCurrentDirectory = $false };
 }
+
+if (Test-Path Function:\TabExpansion) {
+    Rename-Item Function:\TabExpansion TabExpansionBackup
+}
+
+function TabExpansion($line, $lastWord) {
+    $lastBlock = [regex]::Split($line, '[|;]')[-1].TrimStart()
+
+    switch -regex ($lastBlock) {
+        # Execute git tab completion for all svn-related commands
+        "^$(Get-AliasPattern svn) (.*)" { SvnTabExpansion $lastBlock }
+        "^$(Get-AliasPattern tsvn) (.*)" { SvnTabExpansion $lastBlock }
+
+        # Fall back on existing tab expansion
+        default { if (Test-Path Function:\TabExpansionBackup) { TabExpansionBackup $line $lastWord } }
+    }
+}

--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -78,3 +78,7 @@ function tsvn {
   }
 }
 
+function Get-AliasPattern($exe) {
+  $aliases = @($exe) + @(Get-Alias | where { $_.Definition -eq $exe } | select -Exp Name)
+  "($($aliases -join '|'))"
+}

--- a/posh-svn.psm1
+++ b/posh-svn.psm1
@@ -7,6 +7,7 @@ Pop-Location
 Export-ModuleMember -Function @(
   'Write-SvnStatus',
   'Get-SvnStatus',
+  'TabExpansion',
   'SvnTabExpansion',
   'tsvn'
 )

--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -10,30 +10,14 @@ Import-Module .\posh-svn
 
 # Set up a simple prompt, adding the svn prompt parts inside svn repos
 function prompt {
+    $realLASTEXITCODE = $LASTEXITCODE
+
     Write-Host($pwd) -nonewline
-        
-    # Svn Prompt
-    $Global:SvnStatus = Get-SvnStatus
-    Write-SvnStatus $SvnStatus
-      
+
+    Write-VcsStatus
+
+    $global:LASTEXITCODE = $realLASTEXITCODE
     return "> "
 }
-
-if(-not (Test-Path Function:\DefaultTabExpansion)) {
-    Rename-Item Function:\TabExpansion DefaultTabExpansion
-}
-
-# Set up tab expansion and include svn expansion
-function TabExpansion($line, $lastWord) {
-    $lastBlock = [regex]::Split($line, '[|;]')[-1]
-    
-    switch -regex ($lastBlock) {
-        # svn tab expansion
-		'(svn) (.*)' { SvnTabExpansion($lastBlock) }
-        # Fall back on existing tab expansion
-        default { DefaultTabExpansion $line $lastWord }
-    }
-}
-
 
 Pop-Location


### PR DESCRIPTION
Sequence of initializing posh-git and posh-svn no longer matters. Also adopts a couple bug-fixes from posh-git ($LASTEXITCODE -> $global:LASTEXITCODE).
