### PR TITLE
Get-SvnBranch was returning the wrong index with newer version of svn

### DIFF
--- a/SvnUtils.ps1
+++ b/SvnUtils.ps1
@@ -38,12 +38,12 @@ function Get-SvnStatus {
 function Get-SvnBranch {
   if(IsSvnDirectory) {
     $info = svn info
-    $url = $info[1].Replace("URL: ", "") #URL: svn://server/repo/trunk/test
-    $root = $info[2].Replace("Repository Root: ", "") #Repository Root: svn://server/repo
+    $url = $info | ? {$_.StartsWith('URL')} | % {$_.Replace("URL: ", "")} #URL: svn://server/repo/trunk/test
+    $root = $info | ? {$_.StartsWith('Repository Root')} | % {$_.Replace("Repository Root: ", "")} #Repository Root: svn://server/repo
     
     $path = $url.Replace($root, "")
     $pathBits = $path.Split("/", [StringSplitOptions]::RemoveEmptyEntries)
-    
+
     if($pathBits[0] -eq "trunk") {
       return "trunk";
     }


### PR DESCRIPTION
When the `Get-SvnBranch` method was called, it would parse the info using an index. Unfortunately with newer versions of `svn` the index is in a different spot.

I realize this is an old repo, but I thought I'd go ahead and tweak the method so that it'd return the appropriate index.